### PR TITLE
fix: add display property to the footer and reduce the padding

### DIFF
--- a/projects/data-grid/src/lib/components/grid-footer/grid-footer.component.scss
+++ b/projects/data-grid/src/lib/components/grid-footer/grid-footer.component.scss
@@ -1,5 +1,6 @@
 @import "../../../styles/variables";
 
 :host {
-  padding: $size-xxl $size-xl;
+  display: block;
+  padding: $size-m 0;
 }

--- a/projects/data-grid/src/lib/components/grid-row/grid-row.component.scss
+++ b/projects/data-grid/src/lib/components/grid-row/grid-row.component.scss
@@ -27,5 +27,10 @@
       }
     }
   }
+
+  input[type="radio"] {
+    display: block;
+    position: relative;
+  }
 }
 


### PR DESCRIPTION
The footer was overlapping the radio button. To avoid this, add display:block to the footer.