### PR TITLE
feat(grid): Enable filtering without filtering options provided

### DIFF
--- a/projects/data-grid-demo/src/app/components/experience-filter.component.ts
+++ b/projects/data-grid-demo/src/app/components/experience-filter.component.ts
@@ -1,15 +1,8 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { FilteringOptions, GridFilter } from 'ngrx-data-grid';
-import { always, complement, cond, equals, identity, any, none, propEq } from 'ramda';
+import { GridFilter } from 'ngrx-data-grid';
+import { any, propEq } from 'ramda';
 
-const isNotEqual = complement(equals);
 const titleEquals = propEq('title');
-
-const filterByOption = (option: FilteringOptions, value: Date) => cond([
-  [equals(FilteringOptions.None), always(identity)],
-  [equals(FilteringOptions.Equals), always(any(titleEquals(value)))],
-  [equals(FilteringOptions.NotEqual), always(none(titleEquals(value)))]
-])(option);
 
 @Component({
   templateUrl: 'experience-filter.component.html'
@@ -29,18 +22,13 @@ export class ExperienceFilterComponent implements GridFilter<string> {
     'Food Chemist'
   ];
 
-  readonly options = [
-    FilteringOptions.Equals,
-    FilteringOptions.NotEqual
-  ];
-
   onExperienceSelected(event) {
     this.value = event.target.value;
     this.valueChanged.emit(this.value);
   }
 
-  filter({option, value, rawValue: experiences}) {
-    return filterByOption(option, value)(experiences);
+  filter({value, rawValue: experiences}) {
+    return any(titleEquals(value), experiences);
   }
 
   clear(): void {

--- a/projects/data-grid/src/lib/components/filter/dynamic-filter.component.html
+++ b/projects/data-grid/src/lib/components/filter/dynamic-filter.component.html
@@ -1,6 +1,6 @@
 <form novalidate [formGroup]="form" (submit)="onApplyFilter()" class="d-flex flex-direction-column">
 
-  <ngrx-select
+  <ngrx-select *ngIf="filterOptions"
     [options]="filterOptions"
     [formControl]="filterOption"
     (selectionChanged)="onOptionSelected()"

--- a/projects/data-grid/src/lib/components/filter/dynamic-filter.component.ts
+++ b/projects/data-grid/src/lib/components/filter/dynamic-filter.component.ts
@@ -123,7 +123,7 @@ export class DynamicFilterComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private getDefaultFilterOption(): FilteringOptions {
-    return this.filterOptions ? this.filterOptions[0] : FilteringOptions.None;
+    return this.filterOptions ? this.filterOptions[0] : FilteringOptions.Equals;
   }
 
   private createFilterComponent() {

--- a/projects/data-grid/src/lib/components/filter/grid-filter.ts
+++ b/projects/data-grid/src/lib/components/filter/grid-filter.ts
@@ -11,7 +11,7 @@ export interface FilterParams<T> {
 export type FilterFn<T> = (params: FilterParams<T>) => boolean;
 
 export interface GridFilter<T = any> {
-  readonly options: FilteringOptions[];
+  readonly options?: FilteringOptions[];
   option?: FilteringOptions;
   value: T;
   valueChanged: EventEmitter<T>;


### PR DESCRIPTION
If no filtering options are provided then the default filtering
option is based on the equality comparison.