### PR TITLE
ci(update): update build-deploy github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -58,10 +59,15 @@ jobs:
       - name: build
         run: npm run build
 
-      - name: deploy
-        if: success() && github.ref == 'refs/heads/master'
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: deploy 🚀
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
           folder: dist/data-grid-demo


### PR DESCRIPTION
Configure the workflow_dispatch event, to enable triggering of the workflow manually.
Define a deploy as a separate job, that will be triggered on a successful build and when building master branch.
Adjust the configuration of the deploy step (remove branch option, because the default value is gh-pages, the same is true for token option).